### PR TITLE
Used arange instead of linspace for time array

### DIFF
--- a/src/squarewavesimulator/SWV.py
+++ b/src/squarewavesimulator/SWV.py
@@ -2,40 +2,50 @@ import numpy as np
 from scipy.signal import square
 
 class SWV:
-    '''Makes a square wave voltammetry waveform'''
+    """Simulation of square wave voltammetry"""
     
     def __init__(self, Eini = 0, Efin = 1, dEs = 0.002, dEp = 0.05, f = 25, sp = 1000):
+        """Makes an instance of the SWV class and produces sweep, step, and square wave voltammetry waveforms"""
+        
+        '''USER-DEFINED VARIABLES'''
+        self.Eini = Eini                # Initial potential
+        self.Efin = Efin                # Final potential
+        self.dEs = dEs                  # Step potential
+        self.dEp = dEp                  # Pulse amplitude
+        self.f = f                      # Pulse frequency
+        self.sp = sp                    # Data points in a step
 
-        self.Eini = Eini
-        self.Efin = Efin
-        self.dEs = dEs
-        self.dEp = dEp
-        self.f = f
-        self.sp = sp
+        '''DERIVED VARIABLES'''
+        self.window = self.Efin - self.Eini             # Potential window             
+        self.dp = int(self.window / self.dEs)           # Number of steps 
+        self.step_period = 1 / self.f                   # Step interval
 
-        self.window = self.Efin - self.Eini
-        self.dp = int(self.window / self.dEs)
-        self.step_period = 1 / self.f
-        self.pulse_period = self.step_period / 2
-
-
-        self.sweep_time = np.linspace(0 , self.step_period * self.dp, self.dp + 1, endpoint = True)
+        '''TIME INDEX'''
+        self.index = np.arange(0, int(1000 * self.step_period * (self.dp + 1)), int(self.step_period * 1000))
+        
+        '''SWEEP WAVEFORM'''
+        self.sweep_time = self.index / 1000
         self.sweep_waveform = np.linspace(self.Eini, self.Efin, self.dp + 1, endpoint = True)
 
+        '''STEP WAVEFORM'''
         self.step_time = np.array([])
-        for ix in range(0, self.sweep_time.size):
+        for ix in range(0, self.index.size):
             try:
-                self.step_time = np.append(self.step_time, np.linspace(self.sweep_time[ix], self.sweep_time[ix + 1], self.sp))
+                self.step_time = np.append(self.step_time, np.arange(self.index[ix], self.index[ix + 1], (1000 * self.step_period / self.sp))/1000)
             except:
-                pass
+                self.step_time = np.append(self.step_time, np.arange(self.index[ix], self.index[ix] + self.index[1], (1000 * self.step_period / self.sp))/1000)
 
         self.step_waveform = np.array([])
-        for iy in range(1, self.sweep_waveform.size):
+        for iy in range(0, self.sweep_waveform.size):
             self.step_waveform = np.append(self.step_waveform, np.ones((self.sp)) * self.sweep_waveform[iy])
 
+        '''SQUARE WAVE VOLTAMMETRY WAVEFORM'''
         self.square_waveform = square(2 * np.pi * self.f * self.step_time, duty = 0.5) * self.dEp
-        
         self.combined = self.step_waveform + self.square_waveform
+
+
+
+
 
 if __name__ == '__main__':
     


### PR DESCRIPTION
linspace to fill the step time was leaving errors that accumulated over the step

used arange of a 1000* index array to overcome this, then divided by 1000

may need more in future if we want to use graduations less than 1 ms